### PR TITLE
Adding Display progress which is better suited for running projects in parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.github.wokier.progress-maven-plugin</groupId>
 	<artifactId>progress-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>0.5</version>
+	<version>0.6</version>
 	<name>Progress Maven Plugin</name>
 	<url>https://github.com/wokier/progress-maven-plugin</url>
 

--- a/src/main/java/com/github/wokier/maven/progress/DisplayProgressParallelMojo.java
+++ b/src/main/java/com/github/wokier/maven/progress/DisplayProgressParallelMojo.java
@@ -1,0 +1,49 @@
+package com.github.wokier.maven.progress;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Allows to display the progress of a build in a reactor
+ *
+ * @author francois wauquier 'wokier'
+ * @goal display-progress-parallel
+ * @phase validate
+ */
+public class DisplayProgressParallelMojo extends AbstractMojo {
+
+  private static AtomicInteger counter = new AtomicInteger(0);
+	/**
+	 * Reactor Sorted projects; provided by Maven
+	 *
+	 * @parameter expression="${reactorProjects}"
+	 */
+	List<MavenProject> reactorProjects;
+
+	/**
+	 * A list of every project in this reactor; provided by Maven
+	 *
+	 * @parameter expression="${project}"
+	 */
+	MavenProject currentProject;
+
+
+	/**
+	 * @see org.apache.maven.plugin.AbstractMojo#execute()
+	 */
+	public void execute() throws MojoExecutionException, MojoFailureException {
+
+    int next = counter.incrementAndGet();
+		int reactorProjectsCount = reactorProjects.size();
+		File currentProjectBasedir = currentProject.getBasedir();
+
+		getLog().info("Reactor Progress: " + ProgressUtils.progress(next, reactorProjectsCount, currentProjectBasedir));
+	}
+
+}

--- a/src/test/java/com/github/wokier/maven/progress/DisplayProgressParallelMojoTest.java
+++ b/src/test/java/com/github/wokier/maven/progress/DisplayProgressParallelMojoTest.java
@@ -1,0 +1,30 @@
+package com.github.wokier.maven.progress;
+
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+import java.io.File;
+
+public class DisplayProgressParallelMojoTest extends AbstractMojoTestCase {
+
+	public void testExecute() throws Exception {
+
+		File testPom = new File("src/test/resources/test-1-pom.xml");
+
+		Mojo mojo = lookupMojo("display-progress-parallel", testPom);
+
+		assertNotNull(mojo);
+
+	}
+
+	public void testExecuteModules() throws Exception {
+
+		File testPom = new File("src/test/resources/test-modules-pom.xml");
+
+		Mojo mojo = lookupMojo("display-progress-parallel", testPom);
+
+		assertNotNull(mojo);
+
+    }
+
+}


### PR DESCRIPTION
When running mvn with parallel execution ( -T 1C for example) the regular display-progress jumps back and forth because of parallel execution.
This change simply reports consecutively (using a static AtomicInteger) as modules are finished.
The same can be done for The notifications (which brings the question - maybe it's better to have a parameter, or automatically detect if parallel execution is active and switch the report type)

(What do you think?)